### PR TITLE
fix: format:eslint remove svelte extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "format": "npm-run-all -c format:*",
-    "format:eslint": "eslint --fix '**/*.{js,ts,svelte}'",
+    "format:eslint": "eslint --fix '**/*.{js,ts}'",
     "format:prettier": "prettier --write '**/*.{js,ts,svelte,json,md,css}'",
     "lint": "npm-run-all -c lint:*",
     "lint:eslint": "eslint '**/*.{js,ts}'",


### PR DESCRIPTION
Hello, agusID!

I was developing with reference to your repository, but I noticed one problem

It is a bug caused by using eslint-plugin-svelte3 and eslint-plugin-prettier together.

In the current state, if you lint the svelte file, it will break.

For the time being, I tried to remove the svelte file from the format target so as not to brea

https://github.com/sveltejs/svelte/issues/3550


log

```
boilerplate-svelte on  master is 📦 v1.0.0 via ⬢ v11.2.0 took 5s
➜ yarn format:eslint
yarn run v1.12.3
$ eslint --fix '**/*.{js,ts,svelte}'
ParseError: Expected }
  5 | export let url = ''
  6 |
> 7 | {Router,Link,Route,Home,Explore,url;url=0}
    |                                   ^
Occurred while linting /Users/_user_name_/project/other/boilerplate-svelte/src/App.svelte:3
    at error$1 (/Users/_user_name_/project/other/boilerplate-svelte/node_modules/svelte/compiler.js:13329:20)
```